### PR TITLE
Add prescription

### DIFF
--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional, Union
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import HttpUrl
 from sqlmodel import JSON, Column, Field, SQLModel, String
@@ -53,3 +53,11 @@ class Event(SQLModel, table=True):
     unstruct_event_com_snowplowanalytics_snowplow_submit_form_1: Optional[Union[list, dict]] = Field(sa_column=Column(JSON))  # type: ignore
     # Raw useragent
     useragent: str
+
+
+class Prescription(SQLModel, table=True):
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True, nullable=False)
+    prescribe: bool
+    last_updated: datetime
+    # TODO will add this once we have models to work with!
+    # model_id: UUID = Field(foreign_key="model.id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ata-db-models"
-version = "0.0.11"
+version = "0.0.12"
 description = "Database models and migrations for Automating the Ask."
 authors = ["Raaid Arshad <raaid@protonmail.com>"]
 repository = "https://github.com/LocalAtBrown/ata-models"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ import pytest
 from sqlmodel import Session, create_engine, select
 
 from ata_db_models.helpers import Partner
-from ata_db_models.models import Event, SQLModel
+from ata_db_models.models import Event, Prescription, SQLModel
 
 engine = create_engine("postgresql://postgres:postgres@localhost:5432/postgres")
 
@@ -17,7 +17,7 @@ def test_create_tables():
 
 
 @pytest.mark.order(5)
-def test_insert_data():
+def test_insert_event_data() -> None:
     fake_event = Event(
         site_name=Partner.afro_la,
         derived_tstamp=datetime.now(),
@@ -44,3 +44,18 @@ def test_insert_data():
     results = session.exec(statement)
     db_event = results.first()
     assert fake_event == db_event
+
+
+@pytest.mark.order(6)
+def test_insert_prescription_data() -> None:
+    fake_prescription = Prescription(id=uuid4(), prescribe=True, last_updated=datetime.now())
+
+    session = Session(engine)
+    session.add(fake_prescription)
+
+    session.commit()
+
+    statement = select(Prescription)
+    results = session.exec(statement)
+    db_prescription = results.first()
+    assert fake_prescription == db_prescription


### PR DESCRIPTION
Add a simple `Prescription` table with columns for `id`, `prescribe` (a boolean), and `last_updated`. Will update as data science progress is made, but having the simple version here helps us have an end-of-process table to start piping data to to get the mechanics of pipeline1 functional.