### PR TITLE
add api roles

### DIFF
--- a/ata_db_models/db_init_stages/_3_add_api.py
+++ b/ata_db_models/db_init_stages/_3_add_api.py
@@ -1,0 +1,33 @@
+from ata_db_models.helpers import (
+    Component,
+    Grant,
+    Partner,
+    Privilege,
+    RowLevelSecurityPolicy,
+    Stage,
+    post_table_initialization,
+    pre_table_initialization,
+)
+
+
+def add_api(stage: Stage, components: list[Component], partner_names: list[Partner]) -> None:
+    pre_table_initialization(stage=stage, components=components, partner_names=partner_names, create_dbs=False)
+    # SQLAlchemy is idempotent so running this wouldn't break anything, but we don't need to run it
+    # initialize_tables(stage=stage)
+    post_table_initialization(stage=stage, components=components)
+
+
+if __name__ == "__main__":
+    stages = [Stage.dev, Stage.prod]
+    api = Component(
+        name="api",
+        grants=[Grant(privileges=[Privilege.SELECT], tables=["prescription"])],
+        policies=[
+            RowLevelSecurityPolicy(table="prescription", user_column="site_name"),
+        ],
+    )
+    components = [api]
+    partner_names = [Partner.afro_la, Partner.dallas_free_press, Partner.open_vallejo, Partner.the_19th]
+
+    for stage in stages:
+        add_api(stage=stage, components=components, partner_names=partner_names)


### PR DESCRIPTION
Adds a new step to the non-table db management that creates dev and prod api roles that can only select on the prescriptions table, then creates api users for each partner as members of the dev/prod api role. Tested locally, will run pointed at RDS after review and merge.