### PR TITLE
Add group table

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -28,9 +28,9 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         # change this python version if the python version is changed in pyproject.toml and the Dockerfile
         python-version: '3.9.15'

--- a/ata_db_models/db_init_stages/_4_update_api.py
+++ b/ata_db_models/db_init_stages/_4_update_api.py
@@ -1,0 +1,29 @@
+from sqlalchemy.future.engine import create_engine
+
+from ata_db_models.helpers import (
+    Component,
+    Grant,
+    Privilege,
+    Stage,
+    get_conn_string,
+    get_ssm_client,
+    grant_privileges,
+)
+
+if __name__ == "__main__":
+    stages = [Stage.dev, Stage.prod]
+    reader = Component(
+        name="api", grants=[Grant(privileges=[Privilege.SELECT, Privilege.INSERT], tables=["usergroup"])], policies=[]
+    )
+
+    for stage in stages:
+        engine = create_engine(get_conn_string())
+        ssm_client = get_ssm_client()
+        username = f"{stage}_{reader.name}"
+
+        stage_engine = create_engine(get_conn_string(db_name=stage))
+        with stage_engine.connect() as conn:
+            for grant in reader.grants:
+                for table in grant.tables:
+                    grant_privileges(conn=conn, user_or_role=username, table=table, privileges=grant.privileges)
+            conn.commit()

--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -76,7 +76,7 @@ class Prescription(SQLModel, table=True):
 
 
 def default_group() -> Group:
-    return random.choice([g for g in Group])
+    return random.choice([*Group])
 
 
 class UserGroup(SQLModel, table=True):

--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -83,3 +83,4 @@ class UserGroup(SQLModel, table=True):
     user_id: UUID = Field(primary_key=True)
     site_name: str = Field(primary_key=True)
     group: Group = Field(default_factory=default_group)
+    last_updated: datetime = Field(default_factory=datetime.utcnow)

--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -1,3 +1,4 @@
+import random
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Union
@@ -14,6 +15,12 @@ class RefrMedium(str, Enum):
     search = "search"
     social = "social"
     unknown = "unknown"
+
+
+class Group(str, Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
 
 class Event(SQLModel, table=True):
@@ -66,3 +73,13 @@ class Prescription(SQLModel, table=True):
     last_updated: datetime
     # TODO will add this once we have models to work with!
     # model_id: UUID = Field(foreign_key="model.id")
+
+
+def default_group() -> Group:
+    return random.choice([g.value for g in Group])
+
+
+class Group(SQLModel, table=True):
+    user_id: UUID = Field(primary_key=True)
+    site_name: str = Field(primary_key=True)
+    group: Group = Field(default_factory=default_group)

--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -76,10 +76,10 @@ class Prescription(SQLModel, table=True):
 
 
 def default_group() -> Group:
-    return random.choice([g.value for g in Group])
+    return random.choice([g for g in Group])
 
 
-class Group(SQLModel, table=True):
+class UserGroup(SQLModel, table=True):
     user_id: UUID = Field(primary_key=True)
     site_name: str = Field(primary_key=True)
     group: Group = Field(default_factory=default_group)

--- a/ata_db_models/models.py
+++ b/ata_db_models/models.py
@@ -76,7 +76,7 @@ class Prescription(SQLModel, table=True):
 
 
 def default_group() -> Group:
-    return random.choice([*Group])
+    return random.choice([g for g in Group])
 
 
 class UserGroup(SQLModel, table=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ata-db-models"
-version = "0.0.15"
+version = "0.0.16"
 description = "Database models and migrations for Automating the Ask."
 authors = ["Raaid Arshad <raaid@protonmail.com>"]
 repository = "https://github.com/LocalAtBrown/ata-models"


### PR DESCRIPTION
Adds models for a table named UserGroup (shows up in SQL as `usergroup` I believe) with columns for user_id, site_name, and group. User_id + site_name create the primary key (PK), and each PK is assigned to one group, where group is a string-based enum (for now, groups A, B, or C). If a new row is inserted, there is a default function to randomly assign the new user/site combo to one of the groups.

This also adds code to allow the api user to SELECT and INSERT to this new usergroup table.